### PR TITLE
Add example of saving ImagePlus as N5

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ mvn -Dimagej.app.directory=/home/saalfelds/packages/Fiji.app clean install
 Then, in Fiji's Scriptin Interpreter (Plugins > Scripts > Scripting Interpreter), load an N5 dataseets into an `ImagePlus`:
 ```java
 import org.janelia.saalfeldlab.n5.*;
-import org.janelia.saalfeldlab.n5.imglib2.*;
+import org.janelia.saalfeldlab.n5.ij.*;
 
 imp = N5IJUtils.load(new N5FSReader("/home/saalfelds/example.n5"), "/volumes/raw");
 ```

--- a/README.md
+++ b/README.md
@@ -6,12 +6,27 @@ Build into your Fiji installation:
 mvn -Dimagej.app.directory=/home/saalfelds/packages/Fiji.app clean install
 ```
 
-Then, in Fiji's Scriptin Interpreter (Plugins > Scripts > Scripting Interpreter), load an N5 dataseets into an `ImagePlus`:
+Then, in Fiji's Scriptin Interpreter (Plugins > Scripts > Scripting Interpreter), load an N5 dataset into an `ImagePlus`:
 ```java
 import org.janelia.saalfeldlab.n5.*;
 import org.janelia.saalfeldlab.n5.ij.*;
 
 imp = N5IJUtils.load(new N5FSReader("/home/saalfelds/example.n5"), "/volumes/raw");
+```
+
+or save an `ImagePlus` into an N5 dataset:
+```java
+import ij.IJ;
+import org.janelia.saalfeldlab.n5.*;
+import org.janelia.saalfeldlab.n5.ij.*;
+
+N5IJUtils.save(
+    IJ.getImage(),
+    new N5FSWriter("/home/saalfelds/example.n5"),
+    "/volumes/raw",
+    new int[] {128, 128, 64},
+    new GzipCompression()
+);
 ```
 
 More to come...


### PR DESCRIPTION
I was asked how to save an `ImagePlus` as N5 from Fiji and decided to provide a complementary example here in the readme as well.