### PR TITLE
N5 tree discoverer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
 
 		<n5.version>2.0.2</n5.version>
 		<n5-imglib2.version>2.1.1</n5-imglib2.version>
+		<alphanumeric-comparator.version>1.4.1</alphanumeric-comparator.version>
 	</properties>
 
 	<dependencies>
@@ -123,6 +124,11 @@
 		<dependency>
 			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2-ij</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>se.sawano.java</groupId>
+			<artifactId>alphanumeric-comparator</artifactId>
+			<version>${alphanumeric-comparator.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5DatasetDiscoverer.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5DatasetDiscoverer.java
@@ -1,0 +1,100 @@
+package org.janelia.saalfeldlab.n5;
+
+import se.sawano.java.text.AlphanumericComparator;
+
+import javax.swing.tree.DefaultMutableTreeNode;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.text.Collator;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.Optional;
+
+public class N5DatasetDiscoverer {
+
+    private final Comparator<? super String> comparator;
+
+    /**
+     * Creates an N5 discoverer with alphanumeric sorting order of groups/datasets (such as, s9 goes before s10).
+     */
+    public N5DatasetDiscoverer() {
+
+        this(Optional.of(new AlphanumericComparator(Collator.getInstance())));
+    }
+
+    /**
+     * Creates an N5 discoverer.
+     *
+     * If the optional parameter {@code comparator} is specified, the groups and datasets
+     * will be listed in the order determined by this comparator.
+     *
+     * @param comparator
+     */
+    public N5DatasetDiscoverer(final Optional<Comparator<? super String>> comparator) {
+
+        this.comparator = comparator.orElseGet(null);
+    }
+
+    public N5TreeNode discover(final N5Reader n5) throws IOException {
+
+        final N5TreeNode root = new N5TreeNode("/");
+        discover(n5, root);
+        trim(root);
+        if (comparator != null)
+            sort(root, comparator);
+        return root;
+    }
+
+    public static DefaultMutableTreeNode toJTreeNode(final N5TreeNode n5Node)
+    {
+        final DefaultMutableTreeNode node = new DefaultMutableTreeNode(n5Node);
+        for (final N5TreeNode n5ChildNode : n5Node.children)
+            node.add(toJTreeNode(n5ChildNode));
+        return node;
+    }
+
+    private static void discover(final N5Reader n5, final N5TreeNode node) throws IOException {
+
+        if (n5.datasetExists(node.path)) {
+            node.isDataset = true;
+        } else {
+            for (final String childGroup : n5.list(node.path)) {
+                final String childPath = Paths.get(node.path, childGroup).toString();
+                final N5TreeNode childNode = new N5TreeNode(childPath);
+                node.children.add(childNode);
+                discover(n5, childNode);
+            }
+        }
+    }
+
+    /**
+     * Removes branches of the N5 container tree that do not contain datasets.
+     *
+     * @param node
+     * @return
+     *      {@code true} if the branch contains a dataset, {@code false} otherwise
+     */
+    private static boolean trim(final N5TreeNode node)
+    {
+        if (node.children.isEmpty())
+            return node.isDataset;
+
+        boolean ret = false;
+        for (final Iterator<N5TreeNode> it = node.children.iterator(); it.hasNext();)
+        {
+            final N5TreeNode childNode = it.next();
+            if (!trim(childNode))
+                it.remove();
+            else
+                ret = true;
+        }
+        return ret;
+    }
+
+    private static void sort(final N5TreeNode node, final Comparator<? super String> comparator)
+    {
+        node.children.sort(Comparator.comparing(N5TreeNode::toString, comparator));
+        for (final N5TreeNode childNode : node.children)
+            sort(childNode, comparator);
+    }
+}

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5TreeNode.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5TreeNode.java
@@ -20,6 +20,12 @@ public class N5TreeNode {
         return Paths.get(removeLeadingSlash(path)).getFileName().toString();
     }
 
+    @Override
+    public String toString() {
+
+        return getNodeName();
+    }
+
     /**
      * Removes the leading slash from a given path and returns the corrected path.
      * It ensures correctness on both Unix and Windows, otherwise {@code pathName} is treated

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5TreeNode.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5TreeNode.java
@@ -23,7 +23,8 @@ public class N5TreeNode {
     @Override
     public String toString() {
 
-        return getNodeName();
+        final String nodeName = getNodeName();
+        return !nodeName.isEmpty() ? nodeName : "/";
     }
 
     /**

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5TreeNode.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5TreeNode.java
@@ -1,0 +1,35 @@
+package org.janelia.saalfeldlab.n5;
+
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+public class N5TreeNode {
+
+    public final String path;
+    public final List<N5TreeNode> children = new ArrayList<>();
+    public boolean isDataset;
+
+    public N5TreeNode(final String path) {
+
+        this.path = path;
+    }
+
+    public String getNodeName() {
+
+        return Paths.get(removeLeadingSlash(path)).getFileName().toString();
+    }
+
+    /**
+     * Removes the leading slash from a given path and returns the corrected path.
+     * It ensures correctness on both Unix and Windows, otherwise {@code pathName} is treated
+     * as UNC path on Windows, and {@code Paths.get(pathName, ...)} fails with {@code InvalidPathException}.
+     *
+     * @param pathName
+     * @return
+     */
+    protected static String removeLeadingSlash(final String pathName) {
+
+        return pathName.startsWith("/") || pathName.startsWith("\\") ? pathName.substring(1) : pathName;
+    }
+}


### PR DESCRIPTION
* Add common discoverer code that can be used in n5-ij opener plugin and n5-viewer
* Trims branches of the N5 tree that do not contain any datasets
* Sorts groups/datasets in alphanumeric order (such that s9 goes before s10)
* Easy conversion to visual representation as `JTree`

@bogovicj @axtimwalde