### PR TITLE
Speed up downsampling for NativeType

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,15 +89,15 @@
 		<imagej-common.version>2.1.1</imagej-common.version>
 		<imagej-mesh.version>0.8.2</imagej-mesh.version>
 		<imagej-ops.version>2.2.0</imagej-ops.version>
-		<imglib2-algorithm.version>0.15.3</imglib2-algorithm.version>
-		<imglib2-cache.version>1.0.0-beta-18</imglib2-cache.version>
+		<imglib2-algorithm.version>0.16.0</imglib2-algorithm.version>
+		<imglib2-cache.version>1.0.0-beta-19</imglib2-cache.version>
 		<imglib2-ij.version>2.0.2</imglib2-ij.version>
 		<imglib2-realtransform.version>4.0.3</imglib2-realtransform.version>
-		<imglib2-roi.version>0.15.0</imglib2-roi.version>
-		<imglib2.version>7.1.0</imglib2.version>
-		<n5-imglib2.version>7.0.1</n5-imglib2.version>
+		<imglib2-roi.version>0.15.1</imglib2-roi.version>
+		<imglib2.version>7.1.2</imglib2.version>
 		<scijava-common.version>2.99.0</scijava-common.version>
 		<scijava-ui-swing.version>1.0.2</scijava-ui-swing.version>
+		<n5-imglib2.version>7.0.2</n5-imglib2.version>
 	</properties>
 
 	<dependencies>

--- a/src/main/java/org/janelia/saalfeldlab/n5/ij/N5ScalePyramidExporter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/ij/N5ScalePyramidExporter.java
@@ -1261,7 +1261,7 @@ public class N5ScalePyramidExporter extends ContextCommand implements WindowList
 			final RandomAccessibleInterval<T> img, final long[] downsampleFactors) {
 
 		// ensure downsampleFactors contains only 1's and 2's
-		assert Arrays.stream(downsampleFactors).filter(x -> (x == 1) || (x == 2)).count() == downsampleFactors.length;
+		assert Arrays.stream(downsampleFactors).allMatch(x -> (x == 1) || (x == 2));
 
 		final int nd = downsampleFactors.length;
 		final double[] scale = new double[nd];

--- a/src/main/java/org/janelia/saalfeldlab/n5/ij/N5ScalePyramidExporter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/ij/N5ScalePyramidExporter.java
@@ -385,7 +385,7 @@ public class N5ScalePyramidExporter extends ContextCommand implements WindowList
 	}
 
 	/**
-	 * Set the custom metadata mapper to use programmically.
+	 * Set the custom metadata mapper to use programmatically.
 	 *
 	 * @param metadataMapper
 	 *            the metadata template mapper

--- a/src/main/java/org/janelia/saalfeldlab/n5/ij/N5ScalePyramidExporter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/ij/N5ScalePyramidExporter.java
@@ -57,6 +57,11 @@ import javax.swing.JPanel;
 import javax.swing.JTextPane;
 import javax.swing.UIManager;
 
+import net.imglib2.algorithm.blocks.BlockAlgoUtils;
+import net.imglib2.algorithm.blocks.BlockSupplier;
+import net.imglib2.algorithm.blocks.downsample.Downsample;
+import net.imglib2.util.Util;
+import net.imglib2.view.fluent.RandomAccessibleIntervalView.Extension;
 import org.janelia.saalfeldlab.n5.Compression;
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
 import org.janelia.saalfeldlab.n5.GzipCompression;
@@ -1282,11 +1287,25 @@ public class N5ScalePyramidExporter extends ContextCommand implements WindowList
 			}
 		}
 
+		if (img.getType() instanceof NativeType) {
+			return downsampleAvgBy2NativeType((RandomAccessibleInterval) img, Util.long2int(downsampleFactors), dims);
+		}
+
 		// TODO clamping NLinearInterpFactory when relevant
 		// TODO record offset in metadata as (s-0.5)
 		final RealRandomAccessible<T> imgE = Views.interpolate(Views.extendBorder(img), new NLinearInterpolatorFactory());
 		return Views.interval(RealViews.transform(imgE, new ScaleAndTranslation(scale, translation)),
 				new FinalInterval(dims));
+	}
+
+	private static <T extends NativeType<T>> RandomAccessibleInterval<T> downsampleAvgBy2NativeType(
+			final RandomAccessibleInterval<T> img, final int[] downsampleFactors, final long[] dimensions) {
+
+		final int[] cellDimensions = new int[] {32};
+		final BlockSupplier<T> blocks = BlockSupplier
+				.of(img.view().extend(Extension.border()))
+				.andThen(Downsample.downsample(downsampleFactors));
+		return BlockAlgoUtils.cellImg(blocks, dimensions, cellDimensions);
 	}
 
 	private int[] sliceBlockSize(final int exclude) {


### PR DESCRIPTION
In my experiments, this speeds up `DOWN_AVERAGE` by ~50x.

