### PR TITLE
Dataset selector dialog fix2

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/ij/N5Importer.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/ij/N5Importer.java
@@ -42,6 +42,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.swing.JTree;
 
 import org.apache.commons.lang.ArrayUtils;
 import org.janelia.saalfeldlab.n5.DataType;
@@ -62,6 +63,7 @@ import org.janelia.saalfeldlab.n5.metadata.imagej.NgffToImagePlus;
 import org.janelia.saalfeldlab.n5.ui.DataSelection;
 import org.janelia.saalfeldlab.n5.ui.DatasetSelectorDialog;
 import org.janelia.saalfeldlab.n5.ui.N5DatasetTreeCellRenderer;
+import org.janelia.saalfeldlab.n5.ui.N5SwingTreeNode;
 import org.janelia.saalfeldlab.n5.universe.N5DatasetDiscoverer;
 import org.janelia.saalfeldlab.n5.universe.N5Factory;
 import org.janelia.saalfeldlab.n5.universe.N5Factory.StorageFormat;
@@ -253,7 +255,7 @@ public class N5Importer implements PlugIn {
 		this.show = show;
 	}
 
-	public void runWithDialog(final String pathToContainer) {
+	public void runWithDialog(final String pathToContainer, final List<String> selectThisSubPath) {
 		lastOpenedContainer = pathToContainer;
 		selectionDialog = null;
 		run(null);
@@ -261,6 +263,26 @@ public class N5Importer implements PlugIn {
 			throw new RuntimeException("The \"Open N5\" didn't come up when it should.");
 		} else {
 			selectionDialog.detectDatasets();
+			if (selectThisSubPath != null) {
+				boolean isDiscoveryFinished = selectionDialog.waitUntilDiscoveryIsFinished(60000);
+				if (isDiscoveryFinished) selectTreeItem(selectThisSubPath);
+			}
+		}
+	}
+
+	private void selectTreeItem(final List<String> itemPath) {
+		final JTree t = selectionDialog.getJTree();
+		int currRow = 0;
+		for (String subPath : itemPath) {
+			for (int r = currRow; r < t.getRowCount(); ++r, ++currRow) {
+				N5SwingTreeNode n = (N5SwingTreeNode)t.getPathForRow(r).getLastPathComponent();
+				if (n.getNodeName().equals(subPath)) {
+					t.expandRow(r);
+					t.setSelectionRow(r);
+					++currRow;
+					break;
+				}
+			}
 		}
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/ij/N5Importer.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/ij/N5Importer.java
@@ -253,6 +253,17 @@ public class N5Importer implements PlugIn {
 		this.show = show;
 	}
 
+	public void runWithDialog(final String pathToContainer) {
+		lastOpenedContainer = pathToContainer;
+		selectionDialog = null;
+		run(null);
+		if (selectionDialog == null) {
+			throw new RuntimeException("The \"Open N5\" didn't come up when it should.");
+		} else {
+			selectionDialog.detectDatasets();
+		}
+	}
+
 	@Override
 	public void run(final String args) {
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/ui/DatasetSelectorDialog.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/ui/DatasetSelectorDialog.java
@@ -799,6 +799,15 @@ public class DatasetSelectorDialog {
 		detectCalled = true;
 	}
 
+	public boolean waitUntilDiscoveryIsFinished(long maxWaitingMillis) {
+		final long waitingPeriodMillis = 100;
+		while (messageLabel.isVisible() && maxWaitingMillis > 0) {
+			try { Thread.sleep(waitingPeriodMillis); } catch (InterruptedException e) { throw new RuntimeException(e); }
+			maxWaitingMillis -= waitingPeriodMillis;
+		}
+		return !messageLabel.isVisible();
+	}
+
 	public void ok() {
 
 		// stop parsing things

--- a/src/main/java/org/janelia/saalfeldlab/n5/ui/DatasetSelectorDialog.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/ui/DatasetSelectorDialog.java
@@ -30,6 +30,7 @@ import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
+import java.awt.event.KeyEvent;
 import java.io.File;
 import java.net.URI;
 import java.nio.file.Paths;
@@ -49,6 +50,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+import javax.swing.KeyStroke;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JFileChooser;
@@ -94,6 +96,8 @@ import ij.ImageJ;
 import ij.gui.ProgressBar;
 import net.imglib2.util.Pair;
 import se.sawano.java.text.AlphanumericComparator;
+
+import static javax.swing.JComponent.WHEN_IN_FOCUSED_WINDOW;
 
 public class DatasetSelectorDialog {
 
@@ -342,6 +346,10 @@ public class DatasetSelectorDialog {
 
 		// ok and cancel buttons
 		okBtn.addActionListener(e -> ok());
+		okBtn.registerKeyboardAction(a -> ok(),
+				  "n5_open_button",
+				  KeyStroke.getKeyStroke(KeyEvent.VK_ENTER,0,true),
+				  WHEN_IN_FOCUSED_WINDOW);
 		cancelBtn.addActionListener(e -> cancel());
 		dialog.setVisible(true);
 	}
@@ -486,7 +494,7 @@ public class DatasetSelectorDialog {
 		cbot.anchor = GridBagConstraints.CENTER;
 		panel.add(messageLabel, cbot);
 
-		okBtn = new JButton("OK");
+		okBtn = new JButton("Open in Imagej");
 		cbot.gridx = 4;
 		cbot.ipadx = 20;
 		cbot.anchor = GridBagConstraints.EAST;
@@ -503,6 +511,15 @@ public class DatasetSelectorDialog {
 		panel.add(cancelBtn, cbot);
 
 		containerTree.addMouseListener(new NodePopupMenu(this).getPopupListener());
+		containerTree.addTreeSelectionListener(tsl -> {
+			if (containerTree.getSelectionCount() == 0) {
+				okBtn.setEnabled( false );
+			} else {
+				int selectedRow = containerTree.getSelectionRows()[0];
+				N5SwingTreeNode n = (N5SwingTreeNode)containerTree.getPathForRow(selectedRow).getLastPathComponent();
+				okBtn.setEnabled( selectionFilter.test(n.getMetadata()) );
+			}
+		});
 
 		dialog.pack();
 		return dialog;

--- a/src/main/java/org/janelia/saalfeldlab/n5/ui/ImprovedFormattedTextField.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/ui/ImprovedFormattedTextField.java
@@ -67,8 +67,9 @@ public class ImprovedFormattedTextField extends JFormattedTextField {
 	public ImprovedFormattedTextField(AbstractFormatter formatter, Object aValue) {
 
 		this(formatter);
+		String strValue = aValue instanceof String ? (String)aValue : "";
 		try {
-			setValue(new URI(""));
+			setValue(new URI(strValue));
 		} catch (URISyntaxException e) { 
 			e.printStackTrace();
 		}


### PR DESCRIPTION
This PR adds:

- one extra commit left over from the previous PR (sorry for that!)

- `N5Importer.runWithDialog()` to import N5-ish containers always through the GUI dialog.
- the dialog can select/highlight an item at its opening
- the dialog enables/disables 'OK' button based on its availability
- the 'OK' was proposed to be renamed to 'Open in Imagej'
- the `ENTER` key was registered with this button