### PR TITLE
Update `DatasetSelectorDialog` to internally remove trailing slashes

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/ui/DatasetSelectorDialog.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/ui/DatasetSelectorDialog.java
@@ -657,7 +657,7 @@ public class DatasetSelectorDialog {
 		// validate and update input
 		containerPathText.validateAndUpdate();
 
-		final String n5Path = opener.get();
+		final String n5Path = removeTrailingSlash( opener.get() );
 		containerPathUpdateCallback.accept(n5Path);
 
 		if (n5Path == null) {
@@ -991,6 +991,34 @@ public class DatasetSelectorDialog {
 	private static boolean pathsEqual(final String a, final String b) {
 
 		return normalDatasetName(a, "/").equals(normalDatasetName(b, "/"));
+	}
+
+	/**
+	 * Removes a single trailing forward slash ('/') from the given string.
+	 * <p>
+	 * If the string ends with one forward slash, that slash is removed.
+	 * If the string does not end with a slash, it is returned unchanged.
+	 * This method does not remove multiple trailing slashes.
+	 *
+	 * <h3>Examples</h3>
+	 * <pre>
+	 * "/"        → ""
+	 * "abc/"     → "abc"
+	 * "abc///"   → "abc//"
+	 * "abc"      → "abc"
+	 * null       → null
+	 * </pre>
+	 *
+	 * @param s the input string, may be {@code null}
+	 * @return the input string without a single trailing slash, or {@code null} if input was null
+	 */
+	private static String removeTrailingSlash( String s )
+	{
+		if ( s != null && s.endsWith( "/" ) )
+		{
+			return s.substring( 0, s.length() - 1 );
+		}
+		return s;
 	}
 
 	public static class UriValidator extends AbstractFormatter {


### PR DESCRIPTION
This PR updates the `DatasetSelectorDialog` to internally remove trailing slashes from N5 paths before discovery logic starts as trailing slashes seemed to be the cause unexpected behavior in this class.

Resolves: https://github.com/saalfeldlab/n5-ij/issues/119